### PR TITLE
Fix: Prevent Audio Replay for Already Revealed Tiles

### DIFF
--- a/src/GameComponents/GameBoard.java
+++ b/src/GameComponents/GameBoard.java
@@ -134,11 +134,11 @@ public class GameBoard extends JPanel implements MouseListener {
 
         if (e.getButton() == MouseEvent.BUTTON1){
             if (!pressedTile.isFlagged()){
-                if (!FIRST_CLICK && !bottomTiles[row][column].isEmpty() && !bottomTiles[row][column].isBOMB())
+                if (!FIRST_CLICK && !bottomTiles[row][column].isEmpty() && !bottomTiles[row][column].isBOMB() && !topTiles[row][column].isReleased())
                     GameAudio.revealSound(bottomTiles[row][column].getAdjacentBomb());
                 if (FIRST_CLICK){
                     FIRST_CLICK = false;
-                    System.out.println("First Click Done");
+                    System.out.println("First Click Done"); // todo: remove this
                     for (var flaggedLocation:FLAGGED)
                         topTiles[flaggedLocation.x][flaggedLocation.y].setFlaggedQuiet(false);
                     FLAGGED.clear();
@@ -147,10 +147,12 @@ public class GameBoard extends JPanel implements MouseListener {
                     nonBombLocations.add(currentLocation);
                     generateBomb(nonBombLocations);
                 }
-                if (bottomTiles[row][column].isBOMB()) { // where game over is going to be called
+                if (bottomTiles[row][column].isBOMB()) { // todo: where game over is going to be called
 //                    timePanel.stopTimer();
 //                    System.out.println(timePanel.getLabel().getText().split(":").length);
                 }
+                if (!pressedTile.isReleased() && bottomTiles[row][column].isEmpty())
+                    GameAudio.firstClick();
                 pressedTile.released(topTiles, bottomTiles);
                 REVEALED.add(currentLocation);
             }

--- a/src/UiComponents/TopTile.java
+++ b/src/UiComponents/TopTile.java
@@ -87,7 +87,6 @@ public class TopTile extends JPanel {
         this.revalidate();
 
         if (bottomTiles[ROW][COLUMN].isEmpty()){
-            GameAudio.firstClick();
             revealAdjacent(topTiles[ROW][COLUMN].getAdjacent(), topTiles, bottomTiles);
         }
     }


### PR DESCRIPTION
This pull request addresses the issue #3, where the game was incorrectly replaying audio for tiles that had already been revealed when clicked again. 

Changes Made:
- Updated the game logic to include a check preventing the replay of audio for tiles that have been previously revealed.
- Ensured that clicking on a tile that has already been revealed does not trigger the replay of audio.

This fix improves the overall gameplay experience by eliminating unnecessary audio repetition, providing a smoother and more polished interaction for players.

@ablixM  Please review these changes and merge once approved. Thank you!
